### PR TITLE
Make HabitGrid accessible

### DIFF
--- a/Aware/Aware/Grid/HabitGrid.swift
+++ b/Aware/Aware/Grid/HabitGrid.swift
@@ -34,6 +34,8 @@ struct HabitGrid: View {
                         : appState.theme.accentColor.progressOpacity(from: data.minutes)
                     )
                     .aspectRatio(contentMode: .fit)
+                    .accessibilityElement()
+                    .accessibilityLabel("\(data.date)")
             }
         }
         .padding()
@@ -48,6 +50,8 @@ struct HabitGrid: View {
                 
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Historical trends")
     }
 }
 

--- a/Aware/Aware/Screens/DashboardView.swift
+++ b/Aware/Aware/Screens/DashboardView.swift
@@ -51,7 +51,6 @@ struct DashboardView: View {
                 
                 HabitGrid(data: hkData.totalMinutesByDay())
                     .shadow(radius: 4, x: 4)
-                    .accessibilityLabel("Historical trends")
 
                 InsightTile(
                     header: "Keep it up",


### PR DESCRIPTION
The problem was that the HabitGrid is a custom view built with decorative elements (LazyHGrid, RoundedRect) instead of elements that carry semantic meaning. SwiftUI automatically ignores those by default and doesn't expose those elements as part of the accessibility tree. VoiceOver reads what's in the accessibility tree, not what's visually present.

To fix this, we can simply add `.accessibilityElement` on the RoundedRect views (and add a label to it so it's not just an no-name element), and add `.accessibilityElement(children: .contain)` on the parent grid so that we expose it as an accessibility element with a structural role.

Please note that this is the bare minimum to _technically_ make it accessible, but it's likely still insufficient to provide a great experience. If those little squares in the HabitGrid are expected to be interactive, we should instead consider using an element that carry semantic meaning, like Button.